### PR TITLE
break and continue missing, swizzled l-value assignment bug in GLSL

### DIFF
--- a/src/penumbra/translate/c.clj
+++ b/src/penumbra/translate/c.clj
@@ -131,7 +131,7 @@
   [x]
   (cond
     (swizzle? x)
-      (str (apply str (interpose " " (map name (next x)))) (-> x first name))
+      (str (apply parse (interpose " " (map name (next x)))) (-> x first name))
     (symbol? x)
       (let [x* (symbol (.replace (name x) \- \_))]
         (if (:first-appearance (meta x))


### PR DESCRIPTION
Hi Zach,

I've been playing a bit with penumbra and found some minor bugs in the GLSL translation layer:
- the loop break and continue operators were missing
- the assignment to a swizzled l-value didn't translate correctly: `(*= (.rgb sample-color) light-coef)` gave `sample-color.rgb *= light_coef;` instead of `sample_color.rgb *= light_coef;`.

Thanks for your awesome project, it motivated me enough to finally give clojure a try :)

Cheers,
Sebastien
